### PR TITLE
Add Move Object Over Time Script

### DIFF
--- a/Assets/Code/Scripts/MoveObjectOverTime.cs
+++ b/Assets/Code/Scripts/MoveObjectOverTime.cs
@@ -1,0 +1,23 @@
+using Mirror;
+using UnityEngine;
+
+[RequireComponent(typeof(NetworkTransform))]
+public class MoveObjectOverTime : NetworkBehaviour {
+    [SerializeField] private float moveSpeed = 1f;
+
+    [SerializeField] private Vector3[] pathLocations = null;
+    private int pathIndex = 0;
+
+    private void Update() {
+        if (!isServer) return;
+
+        if (Vector3.Distance(gameObject.transform.position, pathLocations[pathIndex]) > 0.01f) {
+            gameObject.transform.position = Vector3.MoveTowards(gameObject.transform.position, pathLocations[pathIndex], Time.deltaTime * moveSpeed);
+        } else {
+            gameObject.transform.position = pathLocations[pathIndex];
+
+            pathIndex++;
+            pathIndex %= pathLocations.Length;
+        }
+    }
+}

--- a/Assets/Code/Scripts/MoveObjectOverTime.cs.meta
+++ b/Assets/Code/Scripts/MoveObjectOverTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d06f5d42531186c4bae355495eb65624
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a script that will allow the server to move an object along a given path over time. Script requires a Network Transform component on the same object to sync it with the clients.