### PR TITLE
Bugfix: Move Objects Once Minigame Starts

### DIFF
--- a/Assets/Code/Scripts/ConstantRotation.cs
+++ b/Assets/Code/Scripts/ConstantRotation.cs
@@ -1,11 +1,24 @@
+using Mirror;
 using UnityEngine;
 
-public class ConstantRotation : MonoBehaviour {
+[RequireComponent(typeof(NetworkTransformReliable))]
+public class ConstantRotation : NetworkBehaviour {
     [Header("Settings")]
     [Tooltip("What axis the object should rotate around. An increased number in a single axis means it will move faster around that axis.")]
     [SerializeField] private Vector3 rotateDirection;
+    [Tooltip("If this object should immediately start moving. If not, it will only start moving once the current minigame starts.")]
+    public bool canMove = false;
+
+    private void Awake() {
+        if (rotateDirection == Vector3.zero) {
+            Debug.LogError("rotateDirection on ConstantRotation is empty. Destroying this ConstantRotation as it's not being used.", gameObject);
+            Destroy(this);
+        }
+    }
 
     private void Update() {
+        if (!isServer || !canMove) return;
+
         transform.Rotate(Time.deltaTime * rotateDirection);
     }
 }

--- a/Assets/Code/Scripts/Managers/ClaimGameManager.cs
+++ b/Assets/Code/Scripts/Managers/ClaimGameManager.cs
@@ -30,7 +30,6 @@ public class ClaimGameManager : NetworkBehaviour {
         StartCoroutine(AddPointsEverySecond());
     }
 
-    /// <summary>Replace maze presets on all clients.</summary>
     [ClientRpc]
     public void RpcEnableTargets() {
         scoreDisplayCanvas.enabled = true;

--- a/Assets/Code/Scripts/Managers/MinigameHandler.cs
+++ b/Assets/Code/Scripts/Managers/MinigameHandler.cs
@@ -14,6 +14,7 @@ public class MinigameHandler : MonoBehaviour {
     public UnityEvent onMinigameEnd = new();
 
     [HideInInspector] public List<List<NetworkConnectionToClient>> winners = new();
+    private List<GameObject> movableObjects = new();
 
     [Header("Settings")]
     [Tooltip("How many seconds the minigame should last before ending.")]
@@ -23,6 +24,18 @@ public class MinigameHandler : MonoBehaviour {
 
     private bool isRunning = false;
     private int winnerCount = 0;
+
+    private void Start() {
+        var moveObjectOverTimes = FindObjectsOfType<MoveObjectOverTime>();
+        foreach (var moveObjectOverTime in moveObjectOverTimes) {
+            movableObjects.Add(moveObjectOverTime.gameObject);
+        }
+
+        var constantRotations = FindObjectsOfType<ConstantRotation>();
+        foreach (var constantRotation in constantRotations) {
+            movableObjects.Add(constantRotation.gameObject);
+        }
+    }
 
     // This is called once all players are ready to start the minigame. Starts a countdown before calling StartMinigame.
     public void StartCountdown() {
@@ -45,6 +58,17 @@ public class MinigameHandler : MonoBehaviour {
             timer.onTimerEnd = onMinigameEnd;
 
             displayTimerUI.RpcStartCountdown(minigameDuration);
+        }
+
+        // Start moving all movable objects.
+        foreach (var movableObject in movableObjects) {
+            if (movableObject.TryGetComponent(out MoveObjectOverTime moveObjectOverTime)) {
+                moveObjectOverTime.canMove = true;
+            }
+
+            if (movableObject.TryGetComponent(out ConstantRotation constantRotation)) {
+                constantRotation.canMove = true;
+            }
         }
 
         onMinigameStart?.Invoke();

--- a/Assets/Code/Scripts/MoveObjectOverTime.cs
+++ b/Assets/Code/Scripts/MoveObjectOverTime.cs
@@ -10,11 +10,20 @@ public class MoveObjectOverTime : NetworkBehaviour {
     [Header("Settings")]
     [Tooltip("How fast the object will move.")]
     [SerializeField] private float moveSpeed = 1f;
+    [Tooltip("If this object should immediately start moving. If not, it will only start moving once the current minigame starts.")]
+    public bool canMove = false;
 
     private int pathIndex = 0;
 
+    private void Awake() {
+        if (pathLocations.Length == 0) {
+            Debug.LogError("PathLocations list on MoveObjectOverTime is empty. Destroying this MoveObjectOverTime as it's not being used.", gameObject);
+            Destroy(this);
+        }
+    }
+
     private void Update() {
-        if (!isServer) return;
+        if (!isServer || !canMove) return;
 
         if (Vector3.Distance(gameObject.transform.position, pathLocations[pathIndex]) > 0.01f) {
             gameObject.transform.position = Vector3.MoveTowards(gameObject.transform.position, pathLocations[pathIndex], Time.deltaTime * moveSpeed);

--- a/Assets/Code/Scripts/MoveObjectOverTime.cs
+++ b/Assets/Code/Scripts/MoveObjectOverTime.cs
@@ -1,4 +1,5 @@
 using Mirror;
+using System.Collections;
 using UnityEngine;
 
 [RequireComponent(typeof(NetworkTransform))]
@@ -10,6 +11,8 @@ public class MoveObjectOverTime : NetworkBehaviour {
     [Header("Settings")]
     [Tooltip("How fast the object will move.")]
     [SerializeField] private float moveSpeed = 1f;
+    [Tooltip("The amount of seconds the object will stop moving for once reaching each position.")]
+    [SerializeField] private float pauseDuration = 0f;
     [Tooltip("If this object should immediately start moving. If not, it will only start moving once the current minigame starts.")]
     public bool canMove = false;
 
@@ -22,16 +25,27 @@ public class MoveObjectOverTime : NetworkBehaviour {
         }
     }
 
-    private void Update() {
-        if (!isServer || !canMove) return;
+    private void Start() {
+        if (!isServer) return;
 
-        if (Vector3.Distance(gameObject.transform.position, pathLocations[pathIndex]) > 0.01f) {
-            gameObject.transform.position = Vector3.MoveTowards(gameObject.transform.position, pathLocations[pathIndex], Time.deltaTime * moveSpeed);
-        } else {
-            gameObject.transform.position = pathLocations[pathIndex];
+        StartCoroutine(UpdateObject());
+    }
 
-            pathIndex++;
-            pathIndex %= pathLocations.Length;
+    private IEnumerator UpdateObject() {
+        while (!canMove) yield return null;  // Wait till the object can move.
+
+        while (true) {
+            if (Vector3.Distance(gameObject.transform.position, pathLocations[pathIndex]) > 0.01f) {
+                gameObject.transform.position = Vector3.MoveTowards(gameObject.transform.position, pathLocations[pathIndex], Time.deltaTime * moveSpeed);
+            } else {
+                yield return new WaitForSeconds(pauseDuration);
+
+                gameObject.transform.position = pathLocations[pathIndex];
+
+                pathIndex++;
+                pathIndex %= pathLocations.Length;
+            }
+            yield return null;
         }
     }
 }

--- a/Assets/Level/Scenes/LobbyScene.unity
+++ b/Assets/Level/Scenes/LobbyScene.unity
@@ -4820,7 +4820,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70736
+  m_Name: pb_Mesh-97664
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -5160,7 +5160,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70680
+  m_Name: pb_Mesh-97608
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -9011,7 +9011,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70694
+  m_Name: pb_Mesh-97622
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -12308,6 +12308,7 @@ MonoBehaviour:
   - {x: 21, y: 23.5, z: 32}
   - {x: 21, y: 13.5, z: 32}
   moveSpeed: 4
+  canMove: 1
 --- !u!114 &546606083
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -16162,7 +16163,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70666
+  m_Name: pb_Mesh-97594
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -21433,7 +21434,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70708
+  m_Name: pb_Mesh-97636
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -21597,7 +21598,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70722
+  m_Name: pb_Mesh-97650
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -26279,7 +26280,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh77516
+  m_Name: pb_Mesh200780
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -26443,7 +26444,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70750
+  m_Name: pb_Mesh-97678
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -27439,7 +27440,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70652
+  m_Name: pb_Mesh-97580
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -30593,7 +30594,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh77770
+  m_Name: pb_Mesh201036
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -30757,7 +30758,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-70638
+  m_Name: pb_Mesh-97566
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -30984,13 +30985,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
         type: 3}
+      propertyPath: availableMinigamesSceneNames.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
+        type: 3}
       propertyPath: availableMinigamesSceneNames.Array.data[0]
       value: MinigameClaimGameScene
       objectReference: {fileID: 0}
     - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
         type: 3}
       propertyPath: availableMinigamesSceneNames.Array.data[1]
-      value: MinigameFlowerChildScene
+      value: MinigameHedgeHurdlersScene
       objectReference: {fileID: 0}
     - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
         type: 3}
@@ -32467,6 +32473,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4855566925072820777, guid: 3b1738b1c18d2ea47918d182e8e20ded,
+        type: 3}
+      propertyPath: sceneId
+      value: 638518682
+      objectReference: {fileID: 0}
     - target: {fileID: 8984738502221015059, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_Mesh
@@ -32475,7 +32486,7 @@ PrefabInstance:
     - target: {fileID: 8984738502221015059, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1771
+      value: 1780
       objectReference: {fileID: 0}
     - target: {fileID: 8984738502221015070, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
@@ -32505,7 +32516,7 @@ PrefabInstance:
     - target: {fileID: 8984738502316917593, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1120
+      value: 1129
       objectReference: {fileID: 0}
     - target: {fileID: 8984738503011602640, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
@@ -32520,13 +32531,18 @@ PrefabInstance:
     - target: {fileID: 8984738503011602644, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1120
+      value: 1129
       objectReference: {fileID: 0}
     - target: {fileID: 8984738503011602647, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1223432161}
+    - target: {fileID: 8984738503168380664, guid: 3b1738b1c18d2ea47918d182e8e20ded,
+        type: 3}
+      propertyPath: canMove
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8984738503168380665, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_RootOrder
@@ -32605,7 +32621,7 @@ PrefabInstance:
     - target: {fileID: 8984738503260383016, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1117
+      value: 1126
       objectReference: {fileID: 0}
     - target: {fileID: 8984738503260383019, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
@@ -32625,7 +32641,7 @@ PrefabInstance:
     - target: {fileID: 8984738503295132161, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1117
+      value: 1126
       objectReference: {fileID: 0}
     - target: {fileID: 8984738503295132172, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
@@ -32655,7 +32671,7 @@ PrefabInstance:
     - target: {fileID: 8984738503298323871, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1114
+      value: 1123
       objectReference: {fileID: 0}
     - target: {fileID: 8984738503591899669, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
@@ -32675,7 +32691,7 @@ PrefabInstance:
     - target: {fileID: 8984738503591900138, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1111
+      value: 1120
       objectReference: {fileID: 0}
     - target: {fileID: 8984738503643229990, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
@@ -32695,7 +32711,7 @@ PrefabInstance:
     - target: {fileID: 8984738503643230011, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1117
+      value: 1126
       objectReference: {fileID: 0}
     - target: {fileID: 8984738503682814304, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
@@ -32705,7 +32721,7 @@ PrefabInstance:
     - target: {fileID: 8984738503682814304, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1114
+      value: 1123
       objectReference: {fileID: 0}
     - target: {fileID: 8984738503682814307, guid: 3b1738b1c18d2ea47918d182e8e20ded,
         type: 3}
@@ -33080,6 +33096,7 @@ MonoBehaviour:
   - {x: 19, y: 5.5, z: 41}
   - {x: 19, y: 15.5, z: 41}
   moveSpeed: 4
+  canMove: 1
 --- !u!114 &2127515655
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Scenes/MinigameFlowerChildScene.unity
+++ b/Assets/Level/Scenes/MinigameFlowerChildScene.unity
@@ -10537,6 +10537,8 @@ GameObject:
   - component: {fileID: 7835733911234296029}
   - component: {fileID: 7835733911234296028}
   - component: {fileID: 7835733911234296032}
+  - component: {fileID: 7835733911234296034}
+  - component: {fileID: 7835733911234296033}
   m_Layer: 0
   m_Name: Cylinder (3)
   m_TagString: Untagged
@@ -12031,7 +12033,62 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61047c527efe523438219ad16c766dcf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   rotateDirection: {x: 45, y: 0, z: 0}
+  canMove: 0
+--- !u!114 &7835733911234296033
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7835733911234296019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff3ba0becae47b8b9381191598957c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
+  target: {fileID: 7835733911234296025}
+  clientAuthority: 0
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 1
+  showGizmos: 0
+  showOverlay: 0
+  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  onlySyncOnChange: 1
+  onlySyncOnChangeCorrectionMultiplier: 2
+  sendIntervalMultiplier: 3
+  rotationSensitivity: 0.01
+  compressRotation: 0
+  positionPrecision: 0.01
+  scalePrecision: 0.01
+  timelineOffset: 0
+--- !u!114 &7835733911234296034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7835733911234296019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 4033973170
+  _assetId: 0
+  serverOnly: 0
+  visible: 0
+  hasSpawned: 0
 --- !u!114 &7835733911330533076
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14282,6 +14339,8 @@ GameObject:
   - component: {fileID: 7835733911637136258}
   - component: {fileID: 7835733911637136257}
   - component: {fileID: 7835733911637136271}
+  - component: {fileID: 7835733911637136273}
+  - component: {fileID: 7835733911637136272}
   m_Layer: 0
   m_Name: Cylinder (2)
   m_TagString: Untagged
@@ -15776,7 +15835,62 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61047c527efe523438219ad16c766dcf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   rotateDirection: {x: 45, y: 0, z: 0}
+  canMove: 0
+--- !u!114 &7835733911637136272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7835733911637136256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff3ba0becae47b8b9381191598957c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
+  target: {fileID: 7835733911637136270}
+  clientAuthority: 0
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 1
+  showGizmos: 0
+  showOverlay: 0
+  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  onlySyncOnChange: 1
+  onlySyncOnChangeCorrectionMultiplier: 2
+  sendIntervalMultiplier: 3
+  rotationSensitivity: 0.01
+  compressRotation: 0
+  positionPrecision: 0.01
+  scalePrecision: 0.01
+  timelineOffset: 0
+--- !u!114 &7835733911637136273
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7835733911637136256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 3202702907
+  _assetId: 0
+  serverOnly: 0
+  visible: 0
+  hasSpawned: 0
 --- !u!114 &7835733911677220576
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -19463,6 +19577,8 @@ GameObject:
   - component: {fileID: 7835733912282553904}
   - component: {fileID: 7835733912282553901}
   - component: {fileID: 7835733912282553900}
+  - component: {fileID: 7835733912282553906}
+  - component: {fileID: 7835733912282553905}
   m_Layer: 0
   m_Name: Cylinder
   m_TagString: Untagged
@@ -20957,7 +21073,62 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61047c527efe523438219ad16c766dcf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   rotateDirection: {x: 45, y: 0, z: 0}
+  canMove: 0
+--- !u!114 &7835733912282553905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7835733912282553891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff3ba0becae47b8b9381191598957c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
+  target: {fileID: 7835733912282553897}
+  clientAuthority: 0
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 1
+  showGizmos: 0
+  showOverlay: 0
+  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  onlySyncOnChange: 1
+  onlySyncOnChangeCorrectionMultiplier: 2
+  sendIntervalMultiplier: 3
+  rotationSensitivity: 0.01
+  compressRotation: 0
+  positionPrecision: 0.01
+  scalePrecision: 0.01
+  timelineOffset: 0
+--- !u!114 &7835733912282553906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7835733912282553891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 185219799
+  _assetId: 0
+  serverOnly: 0
+  visible: 0
+  hasSpawned: 0
 --- !u!23 &7835733912386888240
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -26552,6 +26723,8 @@ GameObject:
   - component: {fileID: 7835733912625817527}
   - component: {fileID: 7835733912625817526}
   - component: {fileID: 7835733912625817528}
+  - component: {fileID: 7835733912625817530}
+  - component: {fileID: 7835733912625817529}
   m_Layer: 0
   m_Name: Cylinder (1)
   m_TagString: Untagged
@@ -26593,7 +26766,62 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61047c527efe523438219ad16c766dcf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
   rotateDirection: {x: 45, y: 0, z: 0}
+  canMove: 0
+--- !u!114 &7835733912625817529
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7835733912625817525}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff3ba0becae47b8b9381191598957c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
+  target: {fileID: 7835733912625817523}
+  clientAuthority: 0
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 1
+  showGizmos: 0
+  showOverlay: 0
+  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  onlySyncOnChange: 1
+  onlySyncOnChangeCorrectionMultiplier: 2
+  sendIntervalMultiplier: 3
+  rotationSensitivity: 0.01
+  compressRotation: 0
+  positionPrecision: 0.01
+  scalePrecision: 0.01
+  timelineOffset: 0
+--- !u!114 &7835733912625817530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7835733912625817525}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 1387068549
+  _assetId: 0
+  serverOnly: 0
+  visible: 0
+  hasSpawned: 0
 --- !u!4 &7835733912686065844
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Instead of having movable objects move at all times, only start moving them once the minigame starts. This includes both MoveObjectOverTime and ConstantRotation objects. Also, synced ConstantRotation over the network. Lastly, added a check for an empty list in MoveObjectOverTime.

A few scenes had to be edited to set asset ids to these objects, these scenes can be overwritten but will need to be opened to set asset ids again.