### PR TITLE
Bugfix: Destroy Bullet After Reaching Distance

### DIFF
--- a/Assets/Code/Scripts/Items/BerryBlaster.cs
+++ b/Assets/Code/Scripts/Items/BerryBlaster.cs
@@ -17,6 +17,7 @@ public class BerryBlaster : RangedWeapon {
         bullet.transform.LookAt(endPos);
         bullet.GetComponent<Bullet>().bulletVelocity = bullet.transform.forward * bulletSpeed;
         bullet.GetComponent<Bullet>().shooterPlayer = playerController.gameObject;
+        bullet.GetComponent<Bullet>().hitDistance = hitDistance;
         bullet.GetComponent<BerryBullet>().bulletColor = playerController.playerColor;
         NetworkServer.Spawn(bullet);
     }

--- a/Assets/Code/Scripts/Items/Bullet.cs
+++ b/Assets/Code/Scripts/Items/Bullet.cs
@@ -4,8 +4,23 @@ using Mirror;
 public abstract class Bullet : NetworkBehaviour {
     [HideInInspector] public GameObject shooterPlayer = null;
     [HideInInspector] public int damage = 10;
+    [HideInInspector] public float hitDistance = float.MaxValue;
 
     [SyncVar(hook = nameof(SetVelocity)), HideInInspector] public Vector3 bulletVelocity = Vector3.zero;
+
+    private Vector3 initialSpawnPos;
+
+    private void OnEnable() {
+        initialSpawnPos = transform.position;
+    }
+
+    private void Update() {
+        if (!isServer) return;
+
+        if (Vector3.Distance(initialSpawnPos, transform.position) >= hitDistance ) {
+            NetworkServer.Destroy(gameObject);
+        }
+    }
 
     private void OnTriggerEnter(Collider other) {
         if (!isServer || other.gameObject == shooterPlayer || (other.transform.parent && other.transform.parent.gameObject == shooterPlayer)) return;

--- a/Assets/Code/Scripts/Items/RangedWeapon.cs
+++ b/Assets/Code/Scripts/Items/RangedWeapon.cs
@@ -27,6 +27,7 @@ public class RangedWeapon : Weapon {
         bullet.transform.LookAt(endPos);
         bullet.GetComponent<Bullet>().bulletVelocity = bullet.transform.forward * bulletSpeed;
         bullet.GetComponent<Bullet>().shooterPlayer = playerController.gameObject;
+        bullet.GetComponent<Bullet>().hitDistance = hitDistance;
         NetworkServer.Spawn(bullet);
     }
 }

--- a/Assets/Level/Prefabs/Items/BerryBlaster.prefab
+++ b/Assets/Level/Prefabs/Items/BerryBlaster.prefab
@@ -55,7 +55,7 @@ MonoBehaviour:
   itemName: Berry Blaster
   useCooldown: 1
   baseDamage: 0
-  hitDistance: 25
+  hitDistance: 100
   bulletPrefab: {fileID: 7524440669711000338, guid: d5009c5ef37e7b04ca20d67569c28f95,
     type: 3}
   bulletSpawnTrans: {fileID: 3374829496812933799}


### PR DESCRIPTION
With weapons having a hit distance, the bullet will now be destroyed when reaching that ranged weapon's distance from it's spawn point.