### PR TITLE
Bugfix: packet loss

### DIFF
--- a/Assets/Code/Scripts/Items/BerryBlaster.cs
+++ b/Assets/Code/Scripts/Items/BerryBlaster.cs
@@ -1,6 +1,3 @@
-using Mirror;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class BerryBlaster : RangedWeapon {
@@ -9,16 +6,5 @@ public class BerryBlaster : RangedWeapon {
 
     private void Start() {
         ammoRenderer.material.color = PlayerColorOptions.options[playerController.playerColor];
-    }
-
-    public override void SpawnBullet(Vector3 endPos) {
-        // Instantiate the bullet across the server. Starting at bulletSpawnTrans's position and move towards endPos.
-        GameObject bullet = Instantiate(bulletPrefab, bulletSpawnTrans.position, bulletSpawnTrans.rotation);
-        bullet.transform.LookAt(endPos);
-        bullet.GetComponent<Bullet>().bulletVelocity = bullet.transform.forward * bulletSpeed;
-        bullet.GetComponent<Bullet>().shooterPlayer = playerController.gameObject;
-        bullet.GetComponent<Bullet>().hitDistance = hitDistance;
-        bullet.GetComponent<BerryBullet>().bulletColor = playerController.playerColor;
-        NetworkServer.Spawn(bullet);
     }
 }

--- a/Assets/Code/Scripts/Items/BerryBullet.cs
+++ b/Assets/Code/Scripts/Items/BerryBullet.cs
@@ -1,10 +1,6 @@
-using Mirror;
 using UnityEngine;
 
 public class BerryBullet : Bullet {
-    [Header("Berry Bullet References")]
-    [SerializeField] private Renderer berryRenderer;
-
     [Header("Berry Bullet Settings")]
     [Tooltip("The amount of force this will knock the hit entity backwards.")]
     [SerializeField] private float knockbackForce = 25f;
@@ -12,12 +8,6 @@ public class BerryBullet : Bullet {
     [SerializeField] private float verticalForce = 5f;
     [Tooltip("How many seconds the hit entity will be stunned for.")]
     [SerializeField] private float stunTime = 0.5f;
-
-    [SyncVar(hook = nameof(SetColor)), HideInInspector] public string bulletColor = "";
-
-    public void SetColor(string oldColor, string newColor) {
-        berryRenderer.material.color = PlayerColorOptions.options[newColor];
-    }
 
     public override void OnHit(GameObject hitObject) {
         base.OnHit(hitObject);

--- a/Assets/Code/Scripts/Items/Bullet.cs
+++ b/Assets/Code/Scripts/Items/Bullet.cs
@@ -1,12 +1,16 @@
-using UnityEngine;
 using Mirror;
+using UnityEngine;
 
 public abstract class Bullet : NetworkBehaviour {
+    [Header("Bullet References")]
+    [SerializeField] private Renderer colorRenderer;
+
     [HideInInspector] public GameObject shooterPlayer = null;
     [HideInInspector] public int damage = 10;
     [HideInInspector] public float hitDistance = float.MaxValue;
 
     [SyncVar(hook = nameof(SetVelocity)), HideInInspector] public Vector3 bulletVelocity = Vector3.zero;
+    [SyncVar(hook = nameof(SetColor)), HideInInspector] public string bulletColor = "";
 
     private Vector3 initialSpawnPos;
 
@@ -17,9 +21,13 @@ public abstract class Bullet : NetworkBehaviour {
     private void Update() {
         if (!isServer) return;
 
-        if (Vector3.Distance(initialSpawnPos, transform.position) >= hitDistance ) {
+        if (Vector3.Distance(initialSpawnPos, transform.position) >= hitDistance) {
             NetworkServer.Destroy(gameObject);
         }
+    }
+
+    public void SetColor(string oldColor, string newColor) {
+        colorRenderer.material.color = PlayerColorOptions.options[newColor];
     }
 
     private void OnTriggerEnter(Collider other) {

--- a/Assets/Code/Scripts/Items/Fist.cs
+++ b/Assets/Code/Scripts/Items/Fist.cs
@@ -10,10 +10,10 @@ public class Fist : MeleeWeapon {
     [SerializeField] private float stunTime = 0.5f;
 
     public override void HitTarget(GameObject target) {
-        if (target && target.TryGetComponent(out PlayerMovementComponent playerMovementComponent)) {
+        if (target && target.GetComponent<PlayerMovementComponent>()) {
             Vector3 direction = playerController.transform.forward * knockbackForce;
             direction.y = verticalForce;
-            playerMovementComponent.TargetKnockbackCharacter(direction, stunTime);
+            playerController.GetComponent<ItemController>().CmdKnockbackCharacter(target, direction, stunTime);
 
             if (target.TryGetComponent(out WispEffect wispEffect) && wispEffect.holdingWisp) {
                 wispEffect.RpcDropWisp();

--- a/Assets/Code/Scripts/Items/MeleeWeapon.cs
+++ b/Assets/Code/Scripts/Items/MeleeWeapon.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using UnityEngine;
 
 public abstract class MeleeWeapon : Weapon {
@@ -26,10 +25,10 @@ public abstract class MeleeWeapon : Weapon {
             }
 
             // If the hit object can be interacted with using on-hit, apply on-hit effects to it.
-            playerController.GetComponent<ItemController>().TargetStartItemCooldown(useCooldown);
+            playerController.GetComponent<ItemController>().StartItemCooldown(useCooldown);
             HitTarget(closestHit.transform.gameObject);
         } else {
-            playerController.GetComponent<ItemController>().TargetStartItemCooldown(missCooldown);
+            playerController.GetComponent<ItemController>().StartItemCooldown(missCooldown);
         }
     }
 

--- a/Assets/Code/Scripts/Items/RangedWeapon.cs
+++ b/Assets/Code/Scripts/Items/RangedWeapon.cs
@@ -1,4 +1,3 @@
-using Mirror;
 using UnityEngine;
 
 public class RangedWeapon : Weapon {
@@ -11,23 +10,15 @@ public class RangedWeapon : Weapon {
     public float bulletSpeed = 30f;
 
     public override void Use() {
-        playerController.GetComponent<ItemController>().TargetStartItemCooldown(useCooldown);
+        playerController.GetComponent<ItemController>().StartItemCooldown(useCooldown);
 
         // Checks if player is looking at an object within maxDistance and set its endPos at the hit object. If there is no object in sight, end bullet at maxDistance.
+        Vector3 endPos;
         if (Physics.Raycast(playerController.playerCamera.gameObject.transform.position, playerController.playerCamera.gameObject.transform.TransformDirection(Vector3.forward), out RaycastHit hit, hitDistance)) {
-            SpawnBullet(hit.point);
+            endPos = hit.point;
         } else {
-            SpawnBullet(playerController.playerCamera.ViewportToWorldPoint(new Vector3(0.5f, 0.5f, hitDistance)));
+            endPos = playerController.playerCamera.ViewportToWorldPoint(new Vector3(0.5f, 0.5f, hitDistance));
         }
-    }
-
-    public virtual void SpawnBullet(Vector3 endPos) {
-        // Instantiate the bullet across the server. Starting at bulletSpawnTrans's position and move towards endPos.
-        GameObject bullet = Instantiate(bulletPrefab, bulletSpawnTrans.position, bulletSpawnTrans.rotation);
-        bullet.transform.LookAt(endPos);
-        bullet.GetComponent<Bullet>().bulletVelocity = bullet.transform.forward * bulletSpeed;
-        bullet.GetComponent<Bullet>().shooterPlayer = playerController.gameObject;
-        bullet.GetComponent<Bullet>().hitDistance = hitDistance;
-        NetworkServer.Spawn(bullet);
+        playerController.GetComponent<ItemController>().SpawnBullet(endPos);
     }
 }

--- a/Assets/Code/Scripts/Items/Weapon.cs
+++ b/Assets/Code/Scripts/Items/Weapon.cs
@@ -7,5 +7,5 @@ public class Weapon : Item {
     [Tooltip("How far this weapon can hit for.")]
     public float hitDistance = 25f;
 
-    public override void Use() {}
+    public override void Use() { }
 }

--- a/Assets/Code/Scripts/Player/PlayerMovementComponent.cs
+++ b/Assets/Code/Scripts/Player/PlayerMovementComponent.cs
@@ -54,11 +54,6 @@ public class PlayerMovementComponent : NetworkBehaviour {
         characterController = GetComponent<CharacterController>();
         playerController = GetComponent<PlayerController>();
         networkAnimator = GetComponent<NetworkAnimator>();
-
-        if (!isLocalPlayer) {
-            Destroy(characterController);
-            Destroy(GetComponent<Rigidbody>());
-        }
     }
 
     // Update is called once per frame
@@ -207,11 +202,11 @@ public class PlayerMovementComponent : NetworkBehaviour {
     /// <summary>Tell the player to knockback themselves.</summary>
     [TargetRpc]
     public void TargetKnockbackCharacter(Vector3 forceDirection, float timeStunned) {
-        KnockbackCharacter(forceDirection);
-        StartCoroutine(StunPlayer(timeStunned));
+        KnockbackCharacter(forceDirection, timeStunned);
     }
 
-    public void KnockbackCharacter(Vector3 forceDirection) {
+    public void KnockbackCharacter(Vector3 forceDirection, float timeStunned) {
+        StartCoroutine(StunPlayer(timeStunned));
         launchVelocity = forceDirection;
         launchTimeElapsed = 0;
         moveDirection.y = forceDirection.y;

--- a/Assets/Code/Scripts/Player/PlayerSync.cs
+++ b/Assets/Code/Scripts/Player/PlayerSync.cs
@@ -9,9 +9,7 @@ public class PlayerSync : NetworkBehaviour {
     [SyncVar] private Vector3 syncPosition;
     [SyncVar] private Quaternion syncRotation;
 
-
-
-    private void Awake() {
+    private void Start() {
         syncPosition = transform.position;
         syncRotation = transform.rotation;
     }

--- a/Assets/Code/Scripts/Tornado.cs
+++ b/Assets/Code/Scripts/Tornado.cs
@@ -11,12 +11,12 @@ public class Tornado : NetworkBehaviour {
     [SerializeField] private float stunTime = 0.5f;
 
     private void OnTriggerEnter(Collider other) {
-        if (!isServer || !other.CompareTag("Player")) return;
+        if (!other.CompareTag("Player")) return;
 
         if (other.gameObject.TryGetComponent(out PlayerMovementComponent playerMovementComponent)) {
             Vector3 direction = (other.transform.position - transform.position).normalized * knockbackForce;
             direction.y = verticalForce;
-            playerMovementComponent.TargetKnockbackCharacter(direction, stunTime);
+            playerMovementComponent.KnockbackCharacter(direction, stunTime);
         }
     }
 }

--- a/Assets/Level/Prefabs/Items/BerryBullet.prefab
+++ b/Assets/Level/Prefabs/Items/BerryBullet.prefab
@@ -51,14 +51,15 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0
+  colorRenderer: {fileID: 2616302144594660857}
   shooterPlayer: {fileID: 0}
   damage: 10
+  hitDistance: 3.4028235e+38
   bulletVelocity: {x: 0, y: 0, z: 0}
-  berryRenderer: {fileID: 2616302144594660857}
+  bulletColor: 
   knockbackForce: 30
   verticalForce: 5
   stunTime: 0.75
-  bulletColor: 
 --- !u!135 &2005529211254197851
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Prefabs/Jumping Fish.prefab
+++ b/Assets/Level/Prefabs/Jumping Fish.prefab
@@ -338,7 +338,7 @@ MonoBehaviour:
   maxRandomJumpTime: 5
   jumpEndDistance: 10
   jumpHeightDistance: 7.5
-  jumpSpeed: 0.012
+  jumpSpeed: 0.01
   knockbackForce: 25
   verticalForce: 5
   stunTime: 0.5

--- a/Assets/Level/Prefabs/Players/Player.prefab
+++ b/Assets/Level/Prefabs/Players/Player.prefab
@@ -254,6 +254,7 @@ GameObject:
   - component: {fileID: 1913241591815720156}
   - component: {fileID: 33998944466195850}
   - component: {fileID: 5385759795732652742}
+  - component: {fileID: -4105487620676779219}
   - component: {fileID: 7876793073482905806}
   - component: {fileID: 5128869810030628217}
   - component: {fileID: 3306933139664286026}
@@ -437,7 +438,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1913241591815720157}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1a66646c345dea94fb39a5d798340a80, type: 3}
   m_Name: 
@@ -446,6 +447,38 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0
   lerpRate: 15
+--- !u!114 &-4105487620676779219
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1913241591815720157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 1
+  syncMode: 0
+  syncInterval: 0
+  target: {fileID: 1913241591815720158}
+  clientAuthority: 0
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 1
+  showGizmos: 0
+  showOverlay: 0
+  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  onlySyncOnChange: 1
+  bufferResetMultiplier: 5
+  positionSensitivity: 0.01
+  rotationSensitivity: 0.01
+  scaleSensitivity: 0.01
+  timelineOffset: 0
 --- !u!114 &7876793073482905806
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Scenes/LobbyScene.unity
+++ b/Assets/Level/Scenes/LobbyScene.unity
@@ -124,13 +124,49 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &83128474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 83128475}
+  m_Layer: 0
+  m_Name: Rotating Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &83128475
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 83128474}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 33.85, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2953473894870493055}
+  - {fileID: 2953473893077515756}
+  - {fileID: 2953473893246156648}
+  - {fileID: 2953473893225454161}
+  - {fileID: 2953473894357997560}
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &98462026
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh196410
+  m_Name: pb_Mesh132440
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -773,7 +809,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-88910
+  m_Name: pb_Mesh132390
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -937,7 +973,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh196446
+  m_Name: pb_Mesh132474
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1101,7 +1137,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh197384
+  m_Name: pb_Mesh133408
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1265,7 +1301,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-89426
+  m_Name: pb_Mesh132658
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1429,7 +1465,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh197102
+  m_Name: pb_Mesh133130
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1593,7 +1629,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh196276
+  m_Name: pb_Mesh132308
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1895,6 +1931,26 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
         type: 3}
+      propertyPath: availableMinigamesScenes.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
+        type: 3}
+      propertyPath: availableMinigamesScenes.Array.data[0]
+      value: Assets/Level/Scenes/MinigameRiverRuckus.unity
+      objectReference: {fileID: 0}
+    - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
+        type: 3}
+      propertyPath: availableMinigamesScenes.Array.data[1]
+      value: Assets/Level/Scenes/MinigameRiverRuckus.unity
+      objectReference: {fileID: 0}
+    - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
+        type: 3}
+      propertyPath: availableMinigamesScenes.Array.data[2]
+      value: Assets/Level/Scenes/MinigameRiverRuckus.unity
+      objectReference: {fileID: 0}
+    - target: {fileID: 4266590026886717781, guid: 4bf61acadb7d1fa44bec3c3834b6074c,
+        type: 3}
       propertyPath: availableMinigamesSceneNames.Array.size
       value: 5
       objectReference: {fileID: 0}
@@ -1936,7 +1992,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-89440
+  m_Name: pb_Mesh132490
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2930,7 +2986,7 @@ Transform:
   - {fileID: 310148096203100258}
   - {fileID: 310148096050732450}
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &310148095206301646
 MonoBehaviour:
@@ -13894,8 +13950,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2953473893077515765}
   m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 33.85, z: 0}
-  m_LocalScale: {x: 1.5000006, y: 1, z: 1.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5000019, y: 1, z: 1.5}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2953473894057034758}
@@ -13934,8 +13990,8 @@ Transform:
   - {fileID: 2953473893051836146}
   - {fileID: 2953473894188100285}
   - {fileID: 2953473893470115225}
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_Father: {fileID: 83128475}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!114 &2953473893077515757
 MonoBehaviour:
@@ -17430,8 +17486,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2953473893225454170}
   m_LocalRotation: {x: -0, y: -0, z: 0.92387956, w: 0.38268343}
-  m_LocalPosition: {x: 0, y: 33.85, z: 0}
-  m_LocalScale: {x: 1.5000002, y: 1, z: 1.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.500001, y: 1, z: 1.5}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2953473893221294147}
@@ -17470,8 +17526,8 @@ Transform:
   - {fileID: 2953473893194542473}
   - {fileID: 2953473894012322566}
   - {fileID: 2953473894330303106}
-  m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_Father: {fileID: 83128475}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 135}
 --- !u!114 &2953473893225454162
 MonoBehaviour:
@@ -19755,7 +19811,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2953473893246156657}
   m_LocalRotation: {x: -0, y: -0, z: 0.38268343, w: 0.92387956}
-  m_LocalPosition: {x: 0, y: 33.85, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.5, y: 1, z: 1.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -19795,8 +19851,8 @@ Transform:
   - {fileID: 2953473893967292887}
   - {fileID: 2953473894167119386}
   - {fileID: 2953473894648211712}
-  m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_Father: {fileID: 83128475}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
 --- !u!114 &2953473893246156649
 MonoBehaviour:
@@ -30472,7 +30528,7 @@ Transform:
   - {fileID: 2953473894507240020}
   - {fileID: 2953473894238593220}
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2953473894312015001
 GameObject:
@@ -30971,13 +31027,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2953473894357997441}
-  m_LocalRotation: {x: 1.110223e-17, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 33.85, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_Father: {fileID: 83128475}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2953473894357997561
 MonoBehaviour:
@@ -69705,7 +69761,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2953473894870492936}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 33.85, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.5, y: 1, z: 1.5}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -69745,8 +69801,8 @@ Transform:
   - {fileID: 2953473893639323178}
   - {fileID: 2953473893078527211}
   - {fileID: 2953473894156480998}
-  m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_Father: {fileID: 83128475}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2953473894889847267
 MeshFilter:

--- a/Assets/Level/Scenes/MinigameRiverRuckus.unity
+++ b/Assets/Level/Scenes/MinigameRiverRuckus.unity
@@ -201,7 +201,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -251,7 +251,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -452,7 +452,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -497,7 +497,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -537,7 +537,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -582,7 +582,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 14
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -622,7 +622,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -667,7 +667,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -707,7 +707,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -752,7 +752,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -841,7 +841,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-131000
+  m_Name: pb_Mesh214456
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1116,7 +1116,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -1158,6 +1158,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
+        type: 3}
+      propertyPath: jumpHeightDistance
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_Name
@@ -1177,7 +1182,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-128696
+  m_Name: pb_Mesh213746
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1360,7 +1365,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -1402,6 +1407,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
+        type: 3}
+      propertyPath: jumpHeightDistance
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_Name
@@ -1421,7 +1431,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-131452
+  m_Name: pb_Mesh214350
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1768,7 +1778,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -1810,6 +1820,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
+        type: 3}
+      propertyPath: jumpHeightDistance
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_Name
@@ -1829,7 +1844,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-130774
+  m_Name: pb_Mesh214476
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2012,7 +2027,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -2053,6 +2068,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
+        type: 3}
+      propertyPath: jumpHeightDistance
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -2216,7 +2236,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-130152
+  m_Name: pb_Mesh214296
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2399,7 +2419,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -2449,7 +2469,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -2575,7 +2595,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -2617,6 +2637,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
+        type: 3}
+      propertyPath: jumpHeightDistance
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_Name
@@ -2655,7 +2680,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -2700,7 +2725,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 14
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -2721,7 +2746,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-129474
+  m_Name: pb_Mesh214444
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2904,7 +2929,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -2946,6 +2971,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
+        type: 3}
+      propertyPath: jumpHeightDistance
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_Name
@@ -2984,7 +3014,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -3034,7 +3064,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -3611,7 +3641,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-131226
+  m_Name: pb_Mesh214396
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -3794,7 +3824,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -3839,7 +3869,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -3879,7 +3909,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -3920,6 +3950,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
+        type: 3}
+      propertyPath: jumpHeightDistance
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4026,7 +4061,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-129926
+  m_Name: pb_Mesh214280
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4221,7 +4256,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4266,7 +4301,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 14
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4498,7 +4533,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4548,7 +4583,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4588,7 +4623,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4633,7 +4668,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4673,7 +4708,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4718,7 +4753,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: jumpHeightDistance
-      value: 10
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -4835,7 +4870,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-129700
+  m_Name: pb_Mesh214410
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -66466,7 +66501,7 @@ PrefabInstance:
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517610, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}
@@ -66507,6 +66542,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362689867368517611, guid: 4ebf472d982420940aafdc61407b5b83,
+        type: 3}
+      propertyPath: jumpHeightDistance
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 8362689867368517621, guid: 4ebf472d982420940aafdc61407b5b83,
         type: 3}


### PR DESCRIPTION
The player sync script would cause a lot of packet loss so I'm disabling and replacing with the unreliable network transform instead. Will need more testing for player movement de sync. At this point, I would rather have player movement de sync over the packet loss anyways. Made some changes to the item controller to make it more client based to be more fluent for the player and a better case for packet loss.